### PR TITLE
update tests on master for review; will expand if :+1:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2
+
+* Update test coverage
+
 # 0.2.1
 
 * Fix archiving

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,5 @@ def inject_databags(server)
     end
   end
 end
+
+ChefSpec::Coverage.start!


### PR DESCRIPTION
@jmccann ... for review and conversation. I'll go into `slave.rb` too if this makes sense.

``` ruby
chef -v
Chef Development Kit Version: 0.14.25
chef-client version: 12.10.24
berks version: 4.3.3
kitchen version: 1.8.0
```

``` ruby
rspec
[2016-06-03T18:04:32+00:00] WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
[2016-06-03T18:04:32+00:00] WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
...................

Finished in 8.54 seconds (files took 2.43 seconds to load)
19 examples, 0 failures


ChefSpec Coverage report generated...

  Total Resources:   8
  Touched Resources: 8
  Touch Coverage:    100.0%

You are awesome and so is your test coverage! Have a fantastic day!

```
